### PR TITLE
Fix error C2445 in wxWebViewMiniBlink::ConvertFrameId()

### DIFF
--- a/WebViewMiniBlink.cpp
+++ b/WebViewMiniBlink.cpp
@@ -93,7 +93,10 @@ void wxWebViewMiniBlink::Shutdown()
 
 wxString wxWebViewMiniBlink::ConvertFrameId(wkeWebView webView, wkeWebFrameHandle frame)
 {
-	return frame == nullptr || wkeIsMainFrame(webView, frame) ? wxEmptyString : wxString::Format("%i", (int)frame);
+    if ( !frame || wkeIsMainFrame(webView, frame) )
+        return wxEmptyString;
+    
+    return wxString::Format("%i", (int)frame);
 }
 
 void wxWebViewMiniBlink::OnTitleChanged(wkeWebView /*webView*/, void* param, const wkeString title)


### PR DESCRIPTION
With MSVC 2017 (Express, v15.8.9, Conformance mode), compilation fails 

> WebViewMiniBlink.cpp
> f:\dev\desktop\myprogs\wxwebviewblink2\webviewminiblink.cpp(96): error C2445: result type of conditional expression is ambiguous: types 'const wxChar *' and 'wxString' can be converted to multiple common types
> f:\dev\desktop\myprogs\wxwebviewblink2\webviewminiblink.cpp(96): note: could be 'const wxChar *'
> f:\dev\desktop!myprogs\wxwebviewblink2\webviewminiblink.cpp(96): note: or       'wxString'
> Done building project "wxtempl.vcxproj" -- FAILED.

This patch simply changes the code so it builds while not affecting its function or requiring setting a compiler option.